### PR TITLE
Default encoding for unicode userid

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 3.5.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Default encoding for createTicket to be compatible with unicode
+  user_id [puittenbroek]
 
 
 3.5.4 (2015-03-21)

--- a/plone/session/tests/testPAS.py
+++ b/plone/session/tests/testPAS.py
@@ -1,15 +1,16 @@
+# -*- coding: utf-8 -*-
 from DateTime import DateTime
 from zope.publisher.browser import TestRequest
 from plone.session.interfaces import ISessionPlugin
 from plone.session.tests.sessioncase import FunctionalPloneSessionTestCase
 
 
-class MockResponse:
+class MockResponse(object):
 
     def setCookie(self, name, value, path,
                   expires=None, secure=False, http_only=False):
-        self.cookie=value
-        self.cookie_expires=expires
+        self.cookie = value
+        self.cookie_expires = expires
         self.cookie_http_only = http_only
         self.secure = secure
 
@@ -19,29 +20,29 @@ class TestSessionPlugin(FunctionalPloneSessionTestCase):
     userid = 'jbloggs'
 
     def testInterfaces(self):
-        session=self.folder.pas.session
+        session = self.folder.pas.session
         self.assertEqual(ISessionPlugin.providedBy(session), True)
 
     def makeRequest(self, cookie):
-        session=self.folder.pas.session
+        session = self.folder.pas.session
         return TestRequest(**{session.cookie_name: cookie})
 
     def testOneLineCookiesOnly(self):
         longid = "x"*256
-        response=MockResponse()
-        session=self.folder.pas.session
+        response = MockResponse()
+        session = self.folder.pas.session
         session._setupSession(longid, response)
         self.assertEqual(len(response.cookie.split()), 1)
 
     def testCookieLifetimeNoExpiration(self):
-        response=MockResponse()
-        session=self.folder.pas.session
+        response = MockResponse()
+        session = self.folder.pas.session
         session._setupSession(self.userid, response)
         self.assertEqual(response.cookie_expires, None)
 
     def testSecureCookies(self):
-        response=MockResponse()
-        session=self.folder.pas.session
+        response = MockResponse()
+        session = self.folder.pas.session
 
         session._setupSession(self.userid, response)
         self.assertEqual(response.secure, False)
@@ -51,34 +52,34 @@ class TestSessionPlugin(FunctionalPloneSessionTestCase):
         self.assertEqual(response.secure, True)
 
     def testCookieHTTPOnly(self):
-        response=MockResponse()
-        session=self.folder.pas.session
+        response = MockResponse()
+        session = self.folder.pas.session
         session._setupSession(self.userid, response)
         self.assertEqual(response.cookie_http_only, True)
 
     def testCookieLifetimeWithExpirationSet(self):
-        response=MockResponse()
-        session=self.folder.pas.session
+        response = MockResponse()
+        session = self.folder.pas.session
         session.cookie_lifetime = 100
         session._setupSession(self.userid, response)
         self.assertEqual(DateTime(response.cookie_expires).strftime('%Y%m%d'),
-                        (DateTime()+100).strftime('%Y%m%d'))
+                         (DateTime()+100).strftime('%Y%m%d'))
 
     def testExtraction(self):
-        session=self.folder.pas.session
+        session = self.folder.pas.session
 
-        request=self.makeRequest("test string".encode("base64"))
-        creds=session.extractCredentials(request)
+        request = self.makeRequest("test string".encode("base64"))
+        creds = session.extractCredentials(request)
         self.assertEqual(creds["source"], "plone.session")
         self.assertEqual(creds["cookie"], "test string")
 
-        request=self.makeRequest("test string")
-        creds=session.extractCredentials(request)
+        request = self.makeRequest("test string")
+        creds = session.extractCredentials(request)
         self.assertEqual(creds, {})
 
     def testCredentialsUpdate(self):
-        session=self.folder.pas.session
-        request=self.makeRequest("test string")
+        session = self.folder.pas.session
+        request = self.makeRequest("test string")
         session.updateCredentials(request, request.response, "bla", "password")
         self.assertEqual(request.response.getCookie(session.cookie_name), None)
 
@@ -88,12 +89,12 @@ class TestSessionPlugin(FunctionalPloneSessionTestCase):
                 None)
 
     def testRefresh(self):
-        session=self.folder.pas.session
-        request=self.makeRequest("test string")
+        session = self.folder.pas.session
+        request = self.makeRequest("test string")
         session.updateCredentials(request, request.response,
                 "our_user", "password")
-        cookie=request.response.getCookie(session.cookie_name)['value']
-        request2=self.makeRequest(cookie)
+        cookie = request.response.getCookie(session.cookie_name)['value']
+        request2 = self.makeRequest(cookie)
         request2.form['type'] = 'gif'
         session.refresh(request2)
         self.assertNotEqual(request2.response.getCookie(session.cookie_name),
@@ -106,8 +107,15 @@ class TestSessionPlugin(FunctionalPloneSessionTestCase):
         # This step would fail.
         session._setupSession(unicode_userid, response)
 
+    def testSpecialCharUserid(self):
+        unicode_userid = u"ãbcdéfghijk"
+        response = MockResponse()
+        session = self.folder.pas.session
+        # This step would fail.
+        session._setupSession(unicode_userid, response)
+
 def test_suite():
     from unittest import TestSuite, makeSuite
-    suite=TestSuite()
+    suite = TestSuite()
     suite.addTest(makeSuite(TestSessionPlugin))
     return suite

--- a/plone/session/tests/testPAS.py
+++ b/plone/session/tests/testPAS.py
@@ -99,6 +99,12 @@ class TestSessionPlugin(FunctionalPloneSessionTestCase):
         self.assertNotEqual(request2.response.getCookie(session.cookie_name),
                 None)
 
+    def testUnicodeUserid(self):
+        unicode_userid = unicode(self.userid)
+        response = MockResponse()
+        session = self.folder.pas.session
+        # This step would fail.
+        session._setupSession(unicode_userid, response)
 
 def test_suite():
     from unittest import TestSuite, makeSuite

--- a/plone/session/tktauth.py
+++ b/plone/session/tktauth.py
@@ -148,7 +148,7 @@ def mod_auth_tkt_digest(secret, data1, data2):
     return digest
 
 
-def createTicket(secret, userid, tokens=(), user_data='', ip='0.0.0.0', timestamp=None, encoding=None, mod_auth_tkt=False):
+def createTicket(secret, userid, tokens=(), user_data='', ip='0.0.0.0', timestamp=None, encoding='utf-8', mod_auth_tkt=False):
     """
     By default, use a more compatible
     """
@@ -158,6 +158,8 @@ def createTicket(secret, userid, tokens=(), user_data='', ip='0.0.0.0', timestam
         userid = userid.encode(encoding)
         tokens = [t.encode(encoding) for t in tokens]
         user_data = user_data.encode(encoding)
+    # if type(userid) == unicode:
+        # userid = userid.encode('utf-8')
 
     token_list = ','.join(tokens)
 


### PR DESCRIPTION
If a PAS Plugin somehow yields a unicode userid, the code starts to fail.
By setting the default encoding, this problem is avoided.

The test in this product all pass, not sure on the bigger picture.