### PR TITLE
Added uninstall profile.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,12 +1,12 @@
 Changelog
 =========
 
-3.5.7 (unreleased)
+3.6.0 (unreleased)
 ------------------
 
 New:
 
-- *add item here*
+- Added uninstall profile.  [maurits]
 
 Fixes:
 

--- a/plone/session/profiles.zcml
+++ b/plone/session/profiles.zcml
@@ -10,4 +10,12 @@
       title="Session refresh support"
   />
 
+  <registerProfile
+      description="Optional plone.session refresh support. [uninstall]"
+      directory="profiles/uninstall"
+      name="uninstall"
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      title="Session refresh support [uninstall]"
+  />
+
 </configure>

--- a/plone/session/profiles/uninstall/cssregistry.xml
+++ b/plone/session/profiles/uninstall/cssregistry.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<object name="portal_css" meta_type="Stylesheets Registry">
+    <stylesheet
+        id="acl_users/session/refresh?session_refresh=true&amp;type=css&amp;minutes=5"
+        remove="true"
+        />
+</object>

--- a/plone/session/profiles/uninstall/jsregistry.xml
+++ b/plone/session/profiles/uninstall/jsregistry.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<object name="portal_javascripts" meta_type="JavaScripts Registry">
+    <javascript
+        id="++resource++plone.session.refreshsupport.js"
+        remove="true"
+        />
+</object>

--- a/plone/session/profiles/uninstall/metadata.xml
+++ b/plone/session/profiles/uninstall/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<metadata>
+  <version>1000</version>
+</metadata>

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-version = '3.5.7.dev0'
+version = '3.6.0.dev0'
 longdescription = open("README.rst").read()
 longdescription += '\n'
 longdescription += open("CHANGES.rst").read()


### PR DESCRIPTION
Needed for plip https://github.com/plone/Products.CMFPlone/issues/1340 otherwise you cannot uninstall plone.session once that plip gets merged.
But fine on its own as well.

Note that plone.session still uses old-style css and javascript registry xml files, which in Plone 5 end up in the new resource registry. The uninstall profile works fine there: the resources are removed from the new resource registry.

The master branch is used on Plone coredev 4.3, 5.0 and 5.1. This particular change would be fine for all three, though only needed on 5.1 (assuming the plip gets finished by then and is included). But I suggest we do this for 5.0 and 5.1.  I will make a branch for maintenance on 4.3.