### PR TITLE
Fix cookie when using Python 3 / Plone 5.2 / Volto / Nginx

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Changelog
 Bug fixes:
 
 
+- Fix session plugin for Python 3 + Plone 5.2 + Volto. [rodfersou] (#18)
 - Fix nameclash resulting in ImportWarning by renaming ``profiles.py`` to ``hiddenprofiles.py``. [jensens] (#16)
 
 

--- a/plone/session/plugins/session.py
+++ b/plone/session/plugins/session.py
@@ -18,6 +18,7 @@ from zope.component import queryUtility
 from zope.interface import implementer
 
 import binascii
+import six
 import time
 
 EMPTY_GIF = (
@@ -176,9 +177,12 @@ class SessionPlugin(BasePlugin):
             return creds
 
         try:
-            creds["cookie"] = binascii.a2b_base64(
+            cookie = binascii.a2b_base64(
                 request.get(self.cookie_name)
             )
+            if six.PY3 and isinstance(cookie, bytes):
+                cookie = cookie.decode('utf-8')
+            creds["cookie"] = cookie
         except binascii.Error:
             # If we have a cookie which is not properly base64 encoded it
             # can not be ours.

--- a/plone/session/plugins/session.py
+++ b/plone/session/plugins/session.py
@@ -6,6 +6,7 @@ from email.utils import formatdate
 from plone.keyring.interfaces import IKeyManager
 from plone.session import tktauth
 from plone.session.interfaces import ISessionPlugin
+from Products.CMFPlone.utils import safe_unicode
 from Products.PageTemplates.PageTemplateFile import PageTemplateFile
 from Products.PluggableAuthService.interfaces.plugins import IAuthenticationPlugin  # noqa
 from Products.PluggableAuthService.interfaces.plugins import ICredentialsResetPlugin  # noqa
@@ -180,8 +181,8 @@ class SessionPlugin(BasePlugin):
             cookie = binascii.a2b_base64(
                 request.get(self.cookie_name)
             )
-            if six.PY3 and isinstance(cookie, bytes):
-                cookie = cookie.decode('utf-8')
+            if not six.PY2 and isinstance(cookie, bytes):
+                cookie = safe_unicode(cookie)
             creds["cookie"] = cookie
         except binascii.Error:
             # If we have a cookie which is not properly base64 encoded it

--- a/plone/session/tests/testPAS.py
+++ b/plone/session/tests/testPAS.py
@@ -86,11 +86,7 @@ class TestSessionPlugin(unittest.TestCase):
         request = self.makeRequest(request_body)
         creds = session.extractCredentials(request)
         self.assertEqual(creds["source"], "plone.session")
-
-        if six.PY2:
-            self.assertEqual(creds["cookie"], b"test string")
-        else:
-            self.assertEqual(creds["cookie"], "test string")
+        self.assertEqual(creds["cookie"], "test string")
 
         request = self.makeRequest("test string")
         creds = session.extractCredentials(request)

--- a/plone/session/tests/testPAS.py
+++ b/plone/session/tests/testPAS.py
@@ -86,7 +86,11 @@ class TestSessionPlugin(unittest.TestCase):
         request = self.makeRequest(request_body)
         creds = session.extractCredentials(request)
         self.assertEqual(creds["source"], "plone.session")
-        self.assertEqual(creds["cookie"], b"test string")
+
+        if six.PY2:
+            self.assertEqual(creds["cookie"], b"test string")
+        else:
+            self.assertEqual(creds["cookie"], "test string")
 
         request = self.makeRequest("test string")
         creds = session.extractCredentials(request)


### PR DESCRIPTION
closes #18 

This error happens when login directly in the backend.
In my test also includes an Nginx mapping the backend to `/api`.

I don't have any idea why the tests are failing.