### PR TITLE
[fixes #22] Per-user keyrings, session invalidation

### DIFF
--- a/news/26.feature.txt
+++ b/news/26.feature.txt
@@ -1,0 +1,1 @@
+Creating per-user keyrings in order to have session invalidation on log-out (server-side logout). [david-batranu]

--- a/plone/session/plugins/secret.pt
+++ b/plone/session/plugins/secret.pt
@@ -73,6 +73,9 @@ By clicking the button below you clear all secrets used to validate sessions.
 This will immediately log out all users who use session authentication and
 require them to log in again.
 </p>
+<p tal:condition="context/per_user_keyring">
+In addition to the system keyring each user keyring will also be invalidated (since per-user keyrings are enabled).
+</p>
 <form method="post" action="." tal:attributes="action string:${context/absolute_url}">
     <input type="submit" name="manage_clearSecrets:method" value="Clear secrets"/>
     <input tal:replace="structure context/@@authenticator/authenticator" />
@@ -86,6 +89,23 @@ were five secrets present.
 </p>
 <form method="post" action="." tal:attributes="action string:${context/absolute_url}">
     <input type="submit" name="manage_createNewSecret:method" value="New secret"/>
+    <input tal:replace="structure context/@@authenticator/authenticator" />
+</form>
+
+<h4>Use per-user keyrings (server-side logout)<span tal:condition="context/per_user_keyring">(enabled)</span></h4>
+<p>
+By clicking the button below a separate keyring will be created for each user when
+they login. The keyring will be cleared and regenerated when the user logs out,
+thus invalidating their session cookie, making it impossible to re-use a previous cookie.
+Per-user keyrings use a single secret.
+</p>
+<p>
+Users that have an active, valid session will still be able to use it (system keyring) until it expires.
+They will then switch to their own keyring when they log in again.
+</p>
+<form method="post" action="." tal:attributes="action string:${context/absolute_url}">
+    <input type="submit" name="manage_togglePerUserKeyring:method"
+        tal:attributes="value python:test(context.per_user_keyring, 'Disable per-user keyrings', 'Enable per-user keyrings')"/>
     <input tal:replace="structure context/@@authenticator/authenticator" />
 </form>
 

--- a/plone/session/plugins/session.py
+++ b/plone/session/plugins/session.py
@@ -8,7 +8,6 @@ from plone.keyring.interfaces import IKeyManager
 from plone.keyring.keyring import Keyring
 from plone.session import tktauth
 from plone.session.interfaces import ISessionPlugin
-from plone.protect.interfaces import IDisableCSRFProtection
 from Products.PageTemplates.PageTemplateFile import PageTemplateFile
 from Products.PluggableAuthService.interfaces.plugins import IAuthenticationPlugin  # noqa
 from Products.PluggableAuthService.interfaces.plugins import ICredentialsResetPlugin  # noqa
@@ -295,10 +294,6 @@ class SessionPlugin(BasePlugin):
     # ICredentialsResetPlugin implementation
     def resetCredentials(self, request, response):
         if self.per_user_keyring:
-            # Prevent plone.protect from redirecting to @@confirm-action
-            # instead of logging-out.
-            # Caused by invalidating the user keyring.
-            alsoProvides(request, IDisableCSRFProtection)
             # Sometimes (found during testing) the __ac cookie is not
             # set by this plugin, and fails the base64 decode.
             # Using extractCredentials again as it safely gets the decoded

--- a/plone/session/tests/testPAS.py
+++ b/plone/session/tests/testPAS.py
@@ -161,3 +161,44 @@ class TestSessionPlugin(unittest.TestCase):
         # This step would fail.
         session._setupSession(unicode_userid, response)
 
+    def testCookieInvalidAfterLogout(self):
+        response = MockResponse()
+        session = self.folder.pas.session
+        session.per_user_keyring = True
+        session._setupSession(self.userid, response)
+
+        cookie = response.cookie
+        request = self.makeRequest(cookie)
+
+        creds = session.extractCredentials(request)
+        auth = session._validateTicket(creds["cookie"])
+        self.assertIsNotNone(auth)
+
+        logout()
+        session.resetCredentials(request, response)
+
+        creds = session.extractCredentials(request)
+        auth = session._validateTicket(creds["cookie"])
+        self.assertIsNone(auth)
+
+    def testCookieValidAfterLogout(self):
+        """Disable per-user keyrings and test that the session
+        is still valid after logout (the usual Plone behavior)."""
+        response = MockResponse()
+        session = self.folder.pas.session
+        session.per_user_keyring = False
+        session._setupSession(self.userid, response)
+
+        cookie = response.cookie
+        request = self.makeRequest(cookie)
+
+        creds = session.extractCredentials(request)
+        auth = session._validateTicket(creds["cookie"])
+        self.assertIsNotNone(auth)
+
+        logout()
+        session.resetCredentials(request, response)
+
+        creds = session.extractCredentials(request)
+        auth = session._validateTicket(creds["cookie"])
+        self.assertIsNotNone(auth)


### PR DESCRIPTION
Generate a Keyring for each user id, this makes it possible to invalidate the keyring on logout, meaning other user sessions using the same authentication token will become invalid.

The change applies only to new sessions, existing sessions will still be able to validate with the `_secret` keyring.

This protects against session stealing (copying the __ac cookie) and creates a working server-side log-out.

I require some input regarding:
 * I only did manual browser testing. I'm not sure how to run the tests.
 * I don't know if this affects other parts of Plone.
 * Should I make this optional? Session invalidation on log-out is considered a security best-practice nowadays.