### PR TITLE
Do not set auth cookie after password reset, unless user is authenticated

### DIFF
--- a/news/3835.bugfix
+++ b/news/3835.bugfix
@@ -1,0 +1,4 @@
+Do not set an auth cookie after password reset, unless the user is authenticated.
+Otherwise anonymous users will be logged in immediately, even when autologin after password reset is false.
+Fixes `issue 3835 <https://github.com/plone/Products.CMFPlone/issues/3835>`_.
+[maurits]

--- a/plone/session/plugins/session.py
+++ b/plone/session/plugins/session.py
@@ -281,8 +281,14 @@ class SessionPlugin(BasePlugin):
         authenticated_user = getSecurityManager().getUser()
         if authenticated_user is not None:
             authenticated_id = authenticated_user.getId()
-            # For anonymous, the id is empty
-            if authenticated_id and authenticated_id != user_id:
+            # For anonymous, the id is empty.
+            if not authenticated_id:
+                # We should not update credentials when there are none currently.
+                # Otherwise for example you are logged in after a password reset,
+                # even when autologin after password reset is false.
+                # See https://github.com/plone/Products.CMFPlone/issues/3835
+                return
+            if authenticated_id != user_id:
                 return
         self._setupSession(user_id, response)
 

--- a/plone/session/tests/testPAS.py
+++ b/plone/session/tests/testPAS.py
@@ -117,7 +117,10 @@ class TestSessionPlugin(unittest.TestCase):
         session = self.folder.pas.session
         request = self.makeRequest("test string")
         session.updateCredentials(request, request.response, "our_user", "password")
-        self.assertIsNotNone(
+        # The anonymous user should not get a cookie: resetCredentials should
+        # not do anything when there are no current credentials.
+        # See https://github.com/plone/Products.CMFPlone/issues/3835
+        self.assertIsNone(
             request.response.getCookie(session.cookie_name),
         )
 
@@ -133,7 +136,7 @@ class TestSessionPlugin(unittest.TestCase):
         logout()
         session = self.folder.pas.session
         request = self.makeRequest("test string")
-        session.updateCredentials(request, request.response, "our_user", "password")
+        session._setupSession(self.userid, request.response)
         cookie = request.response.getCookie(session.cookie_name)["value"]
         request2 = self.makeRequest(cookie)
         request2.form["type"] = "gif"


### PR DESCRIPTION
Otherwise anonymous users will be logged in immediately, even when autologin after password reset is false.
Fixes https://github.com/plone/Products.CMFPlone/issues/3835.